### PR TITLE
Implement service queries for chat completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,8 +263,11 @@ version = "0.1.0"
 dependencies = [
  "async-graphql",
  "async-graphql-derive",
+ "atoma-demo",
  "linera-sdk",
+ "proptest",
  "serde",
+ "test-strategy 0.4.0",
 ]
 
 [[package]]
@@ -368,6 +371,21 @@ dependencies = [
  "serde",
  "thiserror 1.0.69",
 ]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -831,7 +849,7 @@ dependencies = [
  "cranelift-codegen 0.112.3",
  "cranelift-entity 0.112.3",
  "cranelift-frontend 0.112.3",
- "itertools 0.12.1",
+ "itertools",
  "log",
  "smallvec",
  "wasmparser 0.217.0",
@@ -2003,15 +2021,6 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
@@ -2108,7 +2117,7 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "sha3",
- "test-strategy",
+ "test-strategy 0.3.1",
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
@@ -2169,7 +2178,7 @@ dependencies = [
  "serde",
  "serde_json",
  "test-log",
- "test-strategy",
+ "test-strategy 0.3.1",
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
@@ -3031,11 +3040,17 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
 dependencies = [
+ "bit-set",
+ "bit-vec",
  "bitflags 2.8.0",
+ "lazy_static",
  "num-traits",
  "rand",
  "rand_chacha",
  "rand_xorshift",
+ "regex-syntax 0.8.5",
+ "rusty-fork",
+ "tempfile",
  "unarray",
 ]
 
@@ -3055,8 +3070,8 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0f3e5beed80eb580c68e2c600937ac2c4eedabdfd5ef1e5b7ea4f3fba84497b"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.10.5",
+ "heck 0.5.0",
+ "itertools",
  "log",
  "multimap",
  "once_cell",
@@ -3076,7 +3091,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "157c5a9d7ea5c2ed2d9fb8f495b64759f7816c7eaea54ba3978f0d63000162e3"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn 2.0.96",
@@ -3125,6 +3140,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -3470,6 +3491,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
 name = "ruzstd"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3768,7 +3801,19 @@ checksum = "78ad9e09554f0456d67a69c1584c9798ba733a5b50349a6c0d0948710523922d"
 dependencies = [
  "proc-macro2",
  "quote",
- "structmeta-derive",
+ "structmeta-derive 0.2.0",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "structmeta"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e1575d8d40908d70f6fd05537266b90ae71b15dbbe7a8b7dffa2b759306d329"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "structmeta-derive 0.3.0",
  "syn 2.0.96",
 ]
 
@@ -3777,6 +3822,17 @@ name = "structmeta-derive"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a60bcaff7397072dca0017d1db428e30d5002e00b6847703e2e42005c95fbe00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "structmeta-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3952,7 +4008,19 @@ checksum = "b8361c808554228ad09bfed70f5c823caf8a3450b6881cc3a38eb57e8c08c1d9"
 dependencies = [
  "proc-macro2",
  "quote",
- "structmeta",
+ "structmeta 0.2.0",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "test-strategy"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf41af45e3f54cc184831d629d41d5b2bda8297e29c81add7ae4f362ed5e01b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "structmeta 0.3.0",
  "syn 2.0.96",
 ]
 
@@ -4406,6 +4474,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "want"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,6 +264,7 @@ dependencies = [
  "async-graphql",
  "async-graphql-derive",
  "linera-sdk",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,6 +267,7 @@ dependencies = [
  "linera-sdk",
  "proptest",
  "serde",
+ "serde_json",
  "test-strategy 0.4.0",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,7 +268,9 @@ dependencies = [
  "proptest",
  "serde",
  "serde_json",
+ "test-log",
  "test-strategy 0.4.0",
+ "tokio",
 ]
 
 [[package]]
@@ -1200,6 +1202,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.96",
+]
+
+[[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcaee3d8e3cfc3fd92428d477bc97fc29ec8716d180c0d74c643bb26166660e0"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "log",
 ]
 
 [[package]]
@@ -3986,6 +4009,7 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7f46083d221181166e5b6f6b1e5f1d499f3a76888826e6cb1d057554157cd0f"
 dependencies = [
+ "env_logger",
  "test-log-macros",
  "tracing-subscriber",
 ]
@@ -4332,6 +4356,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-serde"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4357,6 +4392,7 @@ dependencies = [
  "thread_local",
  "tracing",
  "tracing-core",
+ "tracing-log",
  "tracing-serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,11 @@ test-strategy = { version = "0.4.0", optional = true }
 atoma-demo = { path = ".", features = ["test"] }
 linera-sdk = { git = "https://github.com/jvff/linera-protocol", rev = "26a5299", features = ["test"] }
 
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+linera-sdk = { git = "https://github.com/jvff/linera-protocol", rev = "26a5299", features = ["test", "wasmer", "unstable-oracles"] }
+tokio = "1.39.3"
+test-log = "*"
+
 [[bin]]
 name = "atoma_demo_contract"
 path = "src/contract.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,13 +3,19 @@ name = "atoma-demo"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+test = ["proptest", "test-strategy"]
+
 [dependencies]
 async-graphql = { version = "=7.0.2", default-features = false }
 async-graphql-derive = { version = "=7.0.2", default-features = false }
 linera-sdk = { git = "https://github.com/jvff/linera-protocol", rev = "26a5299" }
+proptest = { version = "1.6.0", optional = true }
 serde = { version = "1.0.217", features = ["derive"] }
+test-strategy = { version = "0.4.0", optional = true }
 
 [dev-dependencies]
+atoma-demo = { path = ".", features = ["test"] }
 linera-sdk = { git = "https://github.com/jvff/linera-protocol", rev = "26a5299", features = ["test"] }
 
 [[bin]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 async-graphql = { version = "=7.0.2", default-features = false }
 async-graphql-derive = { version = "=7.0.2", default-features = false }
 linera-sdk = { git = "https://github.com/jvff/linera-protocol", rev = "26a5299" }
+serde = { version = "1.0.217", features = ["derive"] }
 
 [dev-dependencies]
 linera-sdk = { git = "https://github.com/jvff/linera-protocol", rev = "26a5299", features = ["test"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ async-graphql-derive = { version = "=7.0.2", default-features = false }
 linera-sdk = { git = "https://github.com/jvff/linera-protocol", rev = "26a5299" }
 proptest = { version = "1.6.0", optional = true }
 serde = { version = "1.0.217", features = ["derive"] }
+serde_json = "1.0.137"
 test-strategy = { version = "0.4.0", optional = true }
 
 [dev-dependencies]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.84.0"
+channel = "1.81.0"
 components = [ "clippy", "rustfmt", "rust-src" ]
 targets = [ "wasm32-unknown-unknown" ]
 profile = "minimal"

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -4,6 +4,9 @@
 #![cfg_attr(target_arch = "wasm32", no_main)]
 
 mod state;
+#[cfg(test)]
+#[path = "./contract_unit_tests.rs"]
+mod tests;
 
 use atoma_demo::{ChatInteraction, Operation};
 use linera_sdk::{

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -5,6 +5,7 @@
 
 mod state;
 
+use atoma_demo::{ChatInteraction, Operation};
 use linera_sdk::{
     base::WithContractAbi,
     views::{RootView, View},
@@ -38,11 +39,23 @@ impl Contract for ApplicationContract {
 
     async fn instantiate(&mut self, _argument: Self::InstantiationArgument) {}
 
-    async fn execute_operation(&mut self, _operation: Self::Operation) -> Self::Response {}
+    async fn execute_operation(&mut self, operation: Self::Operation) -> Self::Response {
+        let Operation::LogChatInteraction { interaction } = operation;
+
+        self.log_chat_interaction(interaction);
+    }
 
     async fn execute_message(&mut self, _message: Self::Message) {}
 
     async fn store(mut self) {
         self.state.save().await.expect("Failed to save state");
+    }
+}
+
+impl ApplicationContract {
+    /// Handles an [`Operation::LogChatInteraction`] by adding a [`ChatInteraction`] to the chat
+    /// log.
+    fn log_chat_interaction(&mut self, interaction: ChatInteraction) {
+        self.state.chat_log.push(interaction);
     }
 }

--- a/src/contract_unit_tests.rs
+++ b/src/contract_unit_tests.rs
@@ -1,0 +1,36 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use atoma_demo::{ChatInteraction, Operation};
+use linera_sdk::{util::BlockingWait, Contract, ContractRuntime};
+use test_strategy::proptest;
+
+use super::ApplicationContract;
+
+/// Tests if chat interactions are logged on chain.
+#[proptest]
+fn chat_interactions_are_logged_on_chain(interactions: Vec<ChatInteraction>) {
+    let mut contract = setup_contract();
+
+    for interaction in interactions.clone() {
+        contract
+            .execute_operation(Operation::LogChatInteraction { interaction })
+            .blocking_wait();
+    }
+
+    let logged_interactions = contract
+        .state
+        .chat_log
+        .read(..)
+        .blocking_wait()
+        .expect("Failed to read logged chat interactions from the state");
+
+    assert_eq!(logged_interactions, interactions);
+}
+
+/// Creates a [`ApplicationContract`] instance to be tested.
+fn setup_contract() -> ApplicationContract {
+    let runtime = ContractRuntime::new();
+
+    ApplicationContract::load(runtime).blocking_wait()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,13 +7,20 @@ use serde::{Deserialize, Serialize};
 pub struct ApplicationAbi;
 
 impl ContractAbi for ApplicationAbi {
-    type Operation = ();
+    type Operation = Operation;
     type Response = ();
 }
 
 impl ServiceAbi for ApplicationAbi {
     type Query = ();
     type QueryResponse = ();
+}
+
+/// Operations that the contract can execute.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub enum Operation {
+    /// Log an interaction with the AI.
+    LogChatInteraction { interaction: ChatInteraction },
 }
 
 /// A single interaction with the AI chat.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use linera_sdk::base::{ContractAbi, ServiceAbi};
+use serde::{Deserialize, Serialize};
 
 pub struct ApplicationAbi;
 
@@ -13,4 +14,11 @@ impl ContractAbi for ApplicationAbi {
 impl ServiceAbi for ApplicationAbi {
     type Query = ();
     type QueryResponse = ();
+}
+
+/// A single interaction with the AI chat.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, async_graphql::SimpleObject)]
+pub struct ChatInteraction {
+    pub prompt: String,
+    pub response: String,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,8 +12,8 @@ impl ContractAbi for ApplicationAbi {
 }
 
 impl ServiceAbi for ApplicationAbi {
-    type Query = ();
-    type QueryResponse = ();
+    type Query = async_graphql::Request;
+    type QueryResponse = async_graphql::Response;
 }
 
 /// Operations that the contract can execute.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ pub enum Operation {
 
 /// A single interaction with the AI chat.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, async_graphql::SimpleObject)]
+#[cfg_attr(feature = "test", derive(test_strategy::Arbitrary))]
 pub struct ChatInteraction {
     pub prompt: String,
     pub response: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,8 @@ pub enum Operation {
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, async_graphql::SimpleObject)]
 #[cfg_attr(feature = "test", derive(test_strategy::Arbitrary))]
 pub struct ChatInteraction {
+    #[cfg_attr(feature = "test", strategy("[A-Za-z0-9., ]*"))]
     pub prompt: String,
+    #[cfg_attr(feature = "test", strategy("[A-Za-z0-9., ]*"))]
     pub response: String,
 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -5,11 +5,15 @@
 
 mod state;
 
+use std::sync::{Arc, Mutex};
+
 use async_graphql::{connection::EmptyFields, EmptyMutation, EmptySubscription, Schema};
 use linera_sdk::{base::WithServiceAbi, Service, ServiceRuntime};
 
 #[derive(Clone)]
-pub struct ApplicationService;
+pub struct ApplicationService {
+    runtime: Arc<Mutex<ServiceRuntime<Self>>>,
+}
 
 linera_sdk::service!(ApplicationService);
 
@@ -20,8 +24,10 @@ impl WithServiceAbi for ApplicationService {
 impl Service for ApplicationService {
     type Parameters = ();
 
-    async fn new(_runtime: ServiceRuntime<Self>) -> Self {
-        ApplicationService
+    async fn new(runtime: ServiceRuntime<Self>) -> Self {
+        ApplicationService {
+            runtime: Arc::new(Mutex::new(runtime)),
+        }
     }
 
     async fn handle_query(&self, query: Self::Query) -> Self::QueryResponse {

--- a/src/service.rs
+++ b/src/service.rs
@@ -5,13 +5,11 @@
 
 mod state;
 
-use self::state::Application;
-use linera_sdk::{base::WithServiceAbi, views::View, Service, ServiceRuntime};
+use async_graphql::{connection::EmptyFields, EmptyMutation, EmptySubscription, Schema};
+use linera_sdk::{base::WithServiceAbi, Service, ServiceRuntime};
 
-pub struct ApplicationService {
-    state: Application,
-    runtime: ServiceRuntime<Self>,
-}
+#[derive(Clone)]
+pub struct ApplicationService;
 
 linera_sdk::service!(ApplicationService);
 
@@ -22,14 +20,14 @@ impl WithServiceAbi for ApplicationService {
 impl Service for ApplicationService {
     type Parameters = ();
 
-    async fn new(runtime: ServiceRuntime<Self>) -> Self {
-        let state = Application::load(runtime.root_view_storage_context())
-            .await
-            .expect("Failed to load state");
-        ApplicationService { state, runtime }
+    async fn new(_runtime: ServiceRuntime<Self>) -> Self {
+        ApplicationService
     }
 
-    async fn handle_query(&self, _query: Self::Query) -> Self::QueryResponse {
-        panic!("Queries not supported by application");
+    async fn handle_query(&self, query: Self::Query) -> Self::QueryResponse {
+        Schema::build(EmptyFields, EmptyMutation, EmptySubscription)
+            .finish()
+            .execute(query)
+            .await
     }
 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -7,8 +7,10 @@ mod state;
 
 use std::sync::{Arc, Mutex};
 
-use async_graphql::{connection::EmptyFields, EmptyMutation, EmptySubscription, Schema};
-use linera_sdk::{base::WithServiceAbi, Service, ServiceRuntime};
+use async_graphql::{connection::EmptyFields, EmptySubscription, Schema};
+use atoma_demo::{ChatInteraction, Operation};
+use linera_sdk::{base::WithServiceAbi, bcs, Service, ServiceRuntime};
+use serde::{Deserialize, Serialize};
 
 #[derive(Clone)]
 pub struct ApplicationService {
@@ -31,9 +33,49 @@ impl Service for ApplicationService {
     }
 
     async fn handle_query(&self, query: Self::Query) -> Self::QueryResponse {
-        Schema::build(EmptyFields, EmptyMutation, EmptySubscription)
-            .finish()
-            .execute(query)
-            .await
+        Schema::build(
+            EmptyFields,
+            Mutation {
+                runtime: self.runtime.clone(),
+            },
+            EmptySubscription,
+        )
+        .finish()
+        .execute(query)
+        .await
     }
+}
+
+/// Root type that defines all the GraphQL mutations available from the service.
+pub struct Mutation {
+    runtime: Arc<Mutex<ServiceRuntime<ApplicationService>>>,
+}
+
+#[async_graphql::Object]
+impl Mutation {
+    /// Executes a chat completion using the Atoma Network.
+    async fn chat(
+        &self,
+        api_token: String,
+        message: ChatMessage,
+    ) -> async_graphql::Result<Vec<u8>> {
+        let interaction = ChatInteraction {
+            prompt: message.content,
+            response: "".to_owned(),
+        };
+
+        Ok(
+            bcs::to_bytes(&Operation::LogChatInteraction { interaction })
+                .expect("`LogChatInteraction` should be serializable"),
+        )
+    }
+}
+
+/// A message to be sent to the AI chat.
+#[derive(Clone, Debug, Deserialize, Serialize, async_graphql::InputObject)]
+pub struct ChatMessage {
+    content: String,
+    role: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -4,6 +4,9 @@
 #![cfg_attr(target_arch = "wasm32", no_main)]
 
 mod state;
+#[cfg(test)]
+#[path = "./service_unit_tests.rs"]
+mod tests;
 
 use std::sync::{Arc, Mutex};
 

--- a/src/service_unit_tests.rs
+++ b/src/service_unit_tests.rs
@@ -1,0 +1,84 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use atoma_demo::{ChatInteraction, Operation};
+use linera_sdk::{bcs, http, util::BlockingWait, Service, ServiceRuntime};
+use serde_json::json;
+use test_strategy::proptest;
+
+use super::{ApplicationService, ATOMA_CLOUD_URL};
+
+/// Tests if `chat` mutations perform an HTTP request to the Atoma proxy, and generates the
+/// operation to log a chat interaction.
+#[proptest]
+fn performs_http_query(
+    #[strategy("[A-Za-z0-9%=]*")] api_token: String,
+    interaction: ChatInteraction,
+) {
+    let service = setup_service();
+
+    let prompt = &interaction.prompt;
+    let request = async_graphql::Request::new(format!(
+        "mutation {{ \
+            chat(\
+                apiToken: \"{api_token}\", \
+                message: {{ \
+                    content: {prompt:?}, \
+                    role: \"user\"
+                }}\
+            ) \
+        }}"
+    ));
+
+    let expected_body = format!(
+        "{{\
+            \"stream\":false,\
+            \"messages\":[\
+                {{\"content\":{prompt:?},\"role\":\"user\"}}\
+            ],\
+            \"model\":\"meta-llama/Llama-3.3-70B-Instruct\",\
+            \"max_tokens\":128\
+        }}"
+    );
+    let mock_response = format!(
+        "{{ \
+            \"choices\": [\
+                {{
+                     \"message\": {{\
+                         \"content\": {:?},
+                         \"role\": \"\"
+                    }}\
+                }}\
+            ] \
+        }}",
+        interaction.response
+    );
+
+    service.runtime.lock().unwrap().add_expected_http_request(
+        http::Request::post(
+            format!("{ATOMA_CLOUD_URL}/v1/chat/completions"),
+            expected_body,
+        )
+        .with_header("Content-Type", b"application/json")
+        .with_header("Authorization", format!("Bearer {api_token}").as_bytes()),
+        http::Response::ok(mock_response),
+    );
+
+    let response = service.handle_query(request).blocking_wait();
+
+    let expected_operation = Operation::LogChatInteraction { interaction };
+    let expected_bytes =
+        bcs::to_bytes(&expected_operation).expect("`Operation` should be serializable");
+    let expected_response = async_graphql::Response::new(
+        async_graphql::Value::from_json(json!({"chat": expected_bytes})).unwrap(),
+    );
+
+    assert_eq!(response, expected_response);
+}
+
+/// Creates a [`ApplicationService`] instance to be tested.
+fn setup_service() -> ApplicationService {
+    let runtime = ServiceRuntime::new();
+
+    ApplicationService::new(runtime).blocking_wait()
+}

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,11 +1,11 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use linera_sdk::views::{linera_views, RegisterView, RootView, ViewStorageContext};
+use atoma_demo::ChatInteraction;
+use linera_sdk::views::{linera_views, LogView, RootView, ViewStorageContext};
 
 #[derive(RootView, async_graphql::SimpleObject)]
 #[view(context = "ViewStorageContext")]
 pub struct Application {
-    pub value: RegisterView<u64>,
-    // Add fields here.
+    pub chat_log: LogView<ChatInteraction>,
 }

--- a/tests/chat_transcript.rs
+++ b/tests/chat_transcript.rs
@@ -1,0 +1,63 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::env;
+
+use atoma_demo::{ApplicationAbi, ChatInteraction, Operation};
+use linera_sdk::{bcs, test::TestValidator};
+
+/// Tests if the service queries the Atoma network when handling a `chat` mutation.
+#[test_log::test(tokio::test)]
+async fn service_queries_atoma() {
+    let (_validator, application_id, chain) =
+        TestValidator::with_current_application::<ApplicationAbi, _, _>((), ()).await;
+
+    let api_token = env::var("ATOMA_API_TOKEN")
+        .expect("Missing ATOMA_API_TOKEN environment variable to run integration test");
+
+    let query = format!(
+        "mutation {{ \
+            chat(\
+                apiToken: \"{api_token}\", \
+                message: {{
+                    content: \"What was the capital of Brazil in 1940\",
+                    role: \"user\"
+                }}\
+            ) \
+        }}"
+    );
+
+    let response = chain.graphql_query(application_id, query).await;
+
+    let response_object = response
+        .as_object()
+        .expect("Unexpected response from service");
+
+    let operation_list = response_object["chat"]
+        .as_array()
+        .expect("Unexpected operation representation returned from service");
+
+    let operation_bytes = operation_list
+        .iter()
+        .map(|value| {
+            let byte_integer = value
+                .as_u64()
+                .expect("Invalid byte type in serialized operation");
+
+            byte_integer
+                .try_into()
+                .expect("Invalid byte value in serialized operation")
+        })
+        .collect::<Vec<u8>>();
+
+    let operation =
+        bcs::from_bytes::<Operation>(&operation_bytes).expect("Failed to deserialize operation");
+
+    let Operation::LogChatInteraction {
+        interaction: ChatInteraction { response, .. },
+    } = operation;
+
+    assert!(response.contains("Rio de Janeiro"));
+}


### PR DESCRIPTION
# Motivation

The goal of this demo is to show how Linera applications can interface with the Atoma Network. As a first step, the application service should be able to query for a chat completion and log the chat interaction on chain.

# Proposal

Update the contract to store a chat log on chain, and add an operation that adds an entry to the chat log.

Add a mutation to the service that queries the Atoma Network using a provided prompt, and creates an operation for the contract to log the chat interaction on chain.

# Testing

Simple unit tests were added to ensure that the contract and the service do their parts, and a simple integration test was implemented to test if the service uses the Atoma proxy correctly. For the integration test to pass, the `ATOMA_API_TOKEN` environment variable must be configured to a valid API key.