### PR TITLE
Register Atoma nodes in a central microchain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,6 +266,7 @@ dependencies = [
  "atoma-demo",
  "linera-sdk",
  "proptest",
+ "rand",
  "serde",
  "serde_json",
  "test-log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ test-strategy = { version = "0.4.0", optional = true }
 [dev-dependencies]
 atoma-demo = { path = ".", features = ["test"] }
 linera-sdk = { git = "https://github.com/jvff/linera-protocol", rev = "26a5299", features = ["test"] }
+rand = "0.8.5"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 linera-sdk = { git = "https://github.com/jvff/linera-protocol", rev = "26a5299", features = ["test", "wasmer", "unstable-oracles"] }

--- a/src/contract_unit_tests.rs
+++ b/src/contract_unit_tests.rs
@@ -1,11 +1,39 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use atoma_demo::{ChatInteraction, Operation};
-use linera_sdk::{util::BlockingWait, Contract, ContractRuntime};
+use std::{
+    collections::{BTreeSet, HashSet},
+    iter,
+};
+
+use atoma_demo::{ChatInteraction, Operation, PublicKey};
+use linera_sdk::{base::ApplicationId, util::BlockingWait, Contract, ContractRuntime};
+use proptest::{
+    prelude::{Arbitrary, BoxedStrategy},
+    sample::size_range,
+    strategy::Strategy,
+};
+use rand::Rng;
 use test_strategy::proptest;
 
 use super::ApplicationContract;
+
+/// Tests if nodes can be added to and removed from the set of active Atoma nodes.
+#[proptest]
+fn updating_nodes(
+    application_id: ApplicationId<atoma_demo::ApplicationAbi>,
+    test_operations: TestUpdateNodesOperations,
+) {
+    let mut test = NodeSetTest::new(application_id);
+
+    for test_operation in test_operations.0 {
+        let operation = test.prepare_operation(test_operation);
+
+        test.contract.execute_operation(operation).blocking_wait();
+
+        test.check_active_atoma_nodes();
+    }
+}
 
 /// Tests if chat interactions are logged on chain.
 #[proptest]
@@ -33,4 +61,141 @@ fn setup_contract() -> ApplicationContract {
     let runtime = ContractRuntime::new();
 
     ApplicationContract::load(runtime).blocking_wait()
+}
+
+/// Helper type with shared code for active Atoma node set tests.
+pub struct NodeSetTest {
+    contract: ApplicationContract,
+    expected_nodes: HashSet<PublicKey>,
+}
+
+impl NodeSetTest {
+    /// Creates a new [`NodeSetTest`], setting up the contract and the runtime.
+    ///
+    /// The test configures the contract to run on the specified `chain_id`, or on the
+    /// application's creation chain if it's [`None`].
+    pub fn new(application_id: ApplicationId<atoma_demo::ApplicationAbi>) -> Self {
+        let mut contract = setup_contract();
+        let chain_id = application_id.creation.chain_id;
+
+        contract.runtime.set_application_id(application_id);
+        contract.runtime.set_chain_id(chain_id);
+
+        NodeSetTest {
+            contract,
+            expected_nodes: HashSet::new(),
+        }
+    }
+
+    /// Prepares an [`Operation::UpdateNodes`] based on the configured
+    /// [`TestUpdateNodesOperation`].
+    ///
+    /// Updates the expected active Atoma nodes state to reflect the execution of the operation.
+    pub fn prepare_operation(&mut self, test_operation: TestUpdateNodesOperation) -> Operation {
+        let nodes_to_add = test_operation.add;
+        let nodes_to_remove = test_operation.remove;
+
+        for node_to_remove in &nodes_to_remove {
+            self.expected_nodes.remove(node_to_remove);
+        }
+
+        self.expected_nodes.extend(nodes_to_add.iter().copied());
+
+        Operation::UpdateNodes {
+            add: nodes_to_add,
+            remove: nodes_to_remove,
+        }
+    }
+
+    /// Asserts that the contract's state has exactly the same nodes as the expected nodes.
+    pub fn check_active_atoma_nodes(&self) {
+        let node_count = self
+            .contract
+            .state
+            .active_atoma_nodes
+            .count()
+            .blocking_wait()
+            .expect("Failed to read active Atoma node set size");
+
+        let mut active_nodes = HashSet::with_capacity(node_count);
+        self.contract
+            .state
+            .active_atoma_nodes
+            .for_each_index(|node| {
+                assert!(
+                    active_nodes.insert(node),
+                    "`SetView` should not have duplicate elements"
+                );
+                Ok(())
+            })
+            .blocking_wait()
+            .expect("Failed to read active Atoma nodes from state");
+
+        assert_eq!(node_count, self.expected_nodes.len());
+        assert_eq!(active_nodes, self.expected_nodes);
+    }
+}
+
+/// A list of test configurations for a sequence of [`Operation::UpdateNodes`].
+#[derive(Clone, Debug)]
+pub struct TestUpdateNodesOperations(Vec<TestUpdateNodesOperation>);
+
+impl Arbitrary for TestUpdateNodesOperations {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<Self>;
+
+    /// Creates an arbitrary [`TestUpdateNodesOperations`].
+    ///
+    /// This is done by creating a random set of nodes, and partitioning it into an arbitrary
+    /// number of operations. After an operation X adds a node for the first time, that node can be
+    /// removed at an operation Y > X, and then re-added at an operation Z > Y, and so on.
+    fn arbitrary_with((): Self::Parameters) -> Self::Strategy {
+        (1_usize..10)
+            .prop_flat_map(|operation_count| {
+                let node_keys = BTreeSet::<PublicKey>::arbitrary_with(size_range(1..100).lift())
+                    .prop_map(Vec::from_iter)
+                    .prop_shuffle();
+
+                node_keys.prop_perturb(move |node_keys, mut random| {
+                    let mut add_operations = iter::repeat(vec![])
+                        .take(operation_count)
+                        .collect::<Vec<_>>();
+                    let mut remove_operations = add_operations.clone();
+
+                    for node_key in node_keys {
+                        let mut is_active = false;
+                        let mut index = 0;
+
+                        random.gen_range(0..operation_count);
+
+                        while index < operation_count {
+                            if is_active {
+                                remove_operations[index].push(node_key);
+                            } else {
+                                add_operations[index].push(node_key);
+                            }
+
+                            is_active = !is_active;
+                            index = random.gen_range(index..operation_count) + 1;
+                        }
+                    }
+
+                    TestUpdateNodesOperations(
+                        add_operations
+                            .into_iter()
+                            .zip(remove_operations)
+                            .map(|(add, remove)| TestUpdateNodesOperation { add, remove })
+                            .collect(),
+                    )
+                })
+            })
+            .boxed()
+    }
+}
+
+/// The test configuration for an [`Operation::UpdateNodes`].
+#[derive(Clone, Debug)]
+pub struct TestUpdateNodesOperation {
+    add: Vec<PublicKey>,
+    remove: Vec<PublicKey>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ pub struct ChatInteraction {
 }
 
 /// Representation of an Atoma node's public key.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[cfg_attr(feature = "test", derive(test_strategy::Arbitrary))]
 pub struct PublicKey([u8; 32]);
 async_graphql::scalar!(PublicKey);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,3 +32,8 @@ pub struct ChatInteraction {
     #[cfg_attr(feature = "test", strategy("[A-Za-z0-9., ]*"))]
     pub response: String,
 }
+
+/// Representation of an Atoma node's public key.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Deserialize, Serialize)]
+pub struct PublicKey([u8; 32]);
+async_graphql::scalar!(PublicKey);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,12 @@ impl ServiceAbi for ApplicationAbi {
 /// Operations that the contract can execute.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum Operation {
+    /// Update the set of active Atoma nodes.
+    UpdateNodes {
+        add: Vec<PublicKey>,
+        remove: Vec<PublicKey>,
+    },
+
     /// Log an interaction with the AI.
     LogChatInteraction { interaction: ChatInteraction },
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,11 +1,12 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use atoma_demo::ChatInteraction;
-use linera_sdk::views::{linera_views, LogView, RootView, ViewStorageContext};
+use atoma_demo::{ChatInteraction, PublicKey};
+use linera_sdk::views::{linera_views, LogView, RootView, SetView, ViewStorageContext};
 
 #[derive(RootView, async_graphql::SimpleObject)]
 #[view(context = "ViewStorageContext")]
 pub struct Application {
+    pub active_atoma_nodes: SetView<PublicKey>,
     pub chat_log: LogView<ChatInteraction>,
 }

--- a/tests/chat_transcript.rs
+++ b/tests/chat_transcript.rs
@@ -57,7 +57,10 @@ async fn service_queries_atoma() {
 
     let Operation::LogChatInteraction {
         interaction: ChatInteraction { response, .. },
-    } = operation;
+    } = operation
+    else {
+        panic!("Unexpected operation returned from service");
+    };
 
     assert!(response.contains("Rio de Janeiro"));
 }


### PR DESCRIPTION
# Motivation

In order to ensure that the AI response came from a trusted Atoma node, the response signature must be verified. To do so, the verifier must know which public keys belong to active Atoma nodes. The long-term plan is to query the state on SUI, but since support for that from Linera isn't ready yet, the information will be stored on a microchain instead.

# Proposal

Add an operation that updates the set of known active Atoma node public keys, and ensure that the set is only stored in the microchain that created the application. That microchain will then be updated with the latest set of Atoma nodes.