### PR TITLE
Allow querying the application's chain state using GraphQL

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,3 +44,9 @@ pub struct ChatInteraction {
 #[cfg_attr(feature = "test", derive(test_strategy::Arbitrary))]
 pub struct PublicKey([u8; 32]);
 async_graphql::scalar!(PublicKey);
+
+impl From<[u8; 32]> for PublicKey {
+    fn from(bytes: [u8; 32]) -> Self {
+        PublicKey(bytes)
+    }
+}

--- a/src/service_unit_tests.rs
+++ b/src/service_unit_tests.rs
@@ -15,7 +15,7 @@ fn performs_http_query(
     #[strategy("[A-Za-z0-9%=]*")] api_token: String,
     interaction: ChatInteraction,
 ) {
-    let service = setup_service();
+    let service = setup_service(ServiceRuntime::new());
 
     let prompt = &interaction.prompt;
     let request = async_graphql::Request::new(format!(
@@ -77,8 +77,6 @@ fn performs_http_query(
 }
 
 /// Creates a [`ApplicationService`] instance to be tested.
-fn setup_service() -> ApplicationService {
-    let runtime = ServiceRuntime::new();
-
+fn setup_service(runtime: ServiceRuntime<ApplicationService>) -> ApplicationService {
     ApplicationService::new(runtime).blocking_wait()
 }

--- a/src/service_unit_tests.rs
+++ b/src/service_unit_tests.rs
@@ -2,11 +2,74 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use atoma_demo::{ChatInteraction, Operation};
-use linera_sdk::{bcs, http, util::BlockingWait, Service, ServiceRuntime};
+use linera_sdk::{
+    bcs, http,
+    util::BlockingWait,
+    views::{RootView, View},
+    Service, ServiceRuntime, ViewStorageContext,
+};
 use serde_json::json;
 use test_strategy::proptest;
 
-use super::{ApplicationService, ATOMA_CLOUD_URL};
+use super::{state::Application, ApplicationService, ATOMA_CLOUD_URL};
+
+/// Tests if the chat logged on chain can be inspected with GraphQL.
+#[proptest]
+fn read_chat_log(interactions: Vec<ChatInteraction>) {
+    let runtime = ServiceRuntime::new();
+    let storage = runtime.key_value_store().to_mut();
+
+    let mut initial_state = Application::load(ViewStorageContext::new_unsafe(storage, vec![], ()))
+        .blocking_wait()
+        .expect("Failed to load state from mock storage");
+
+    for interaction in interactions.iter().cloned() {
+        initial_state.chat_log.push(interaction);
+    }
+
+    initial_state
+        .save()
+        .blocking_wait()
+        .expect("Failed to save initial state to mock storage");
+
+    let service = setup_service(runtime);
+
+    let request = async_graphql::Request::new("query { chatLog { entries { prompt, response } } }");
+
+    let response = service.handle_query(request).blocking_wait();
+
+    let async_graphql::Value::Object(response_data) = response.data else {
+        panic!("Unexpected response data type");
+    };
+    let async_graphql::Value::Object(ref chat_log) = response_data["chatLog"] else {
+        panic!("Unexpected response chat log type");
+    };
+    let async_graphql::Value::List(ref entries) = chat_log["entries"] else {
+        panic!("Unexpected response entries type");
+    };
+
+    let persisted_interactions = entries
+        .iter()
+        .map(|entry_value| {
+            let async_graphql::Value::Object(entry) = entry_value else {
+                panic!("Unexpected interaction entry type");
+            };
+            let async_graphql::Value::String(ref prompt) = entry["prompt"] else {
+                panic!("Unexpected interaction prompt type");
+            };
+            let async_graphql::Value::String(ref response) = entry["response"] else {
+                panic!("Unexpected interaction response type");
+            };
+
+            ChatInteraction {
+                prompt: prompt.clone(),
+                response: response.clone(),
+            }
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(persisted_interactions, interactions);
+}
 
 /// Tests if `chat` mutations perform an HTTP request to the Atoma proxy, and generates the
 /// operation to log a chat interaction.


### PR DESCRIPTION
# Motivation

The on-chain state of the application should be able to be inspected using the service. Therefore GraphQL queries to the service state should be supported.

# Proposal

Load the state in the service and make it available for inspection through GraphQL.