### PR TITLE
Verify chat interactions on the central chain

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -65,7 +65,7 @@ impl Contract for ApplicationContract {
 }
 
 /// Cross-chain messages sent privately between the application shards.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub enum Message {
     /// Request to verify a [`ChatInteraction`]'s signature.
     VerifySignature(ChatInteraction),

--- a/src/contract_unit_tests.rs
+++ b/src/contract_unit_tests.rs
@@ -20,7 +20,7 @@ use proptest::{
 use rand::Rng;
 use test_strategy::proptest;
 
-use super::ApplicationContract;
+use super::{ApplicationContract, Message};
 
 /// Tests if nodes can be added to and removed from the set of active Atoma nodes.
 #[proptest]
@@ -98,12 +98,12 @@ fn cant_add_and_remove_node_in_the_same_operation(
 
 /// Tests if chat interactions are logged on chain.
 #[proptest]
-fn chat_interactions_are_logged_on_chain(interactions: Vec<ChatInteraction>) {
+fn verified_chat_interactions_are_logged_on_chain(interactions: Vec<ChatInteraction>) {
     let mut contract = setup_contract();
 
     for interaction in interactions.clone() {
         contract
-            .execute_operation(Operation::LogChatInteraction { interaction })
+            .execute_message(Message::LogVerifiedChatInteraction(interaction))
             .blocking_wait();
     }
 


### PR DESCRIPTION
# Motivation

PR #2 introduces a microchain that contains a registry of active Atoma nodes. That microchain should be used to verify if chat interactions came from trusted Atoma nodes.

# Proposal

Send a message to the verifier microchain to check the chat interaction's signature. Signature verification is not yet implemented. For now the chain assumes that it is valid and sends a message back to the requester allowing it to store the interaction on chain.